### PR TITLE
Automatically attach ZIP archive when publishing a new GitHub Release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.* export-ignore

--- a/.github/workflows/create-release-attachment.yml
+++ b/.github/workflows/create-release-attachment.yml
@@ -1,0 +1,24 @@
+name: Attach ZIP to GitHub Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  attach-zip:
+    name: Attach ZIP to release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+          coverage: none
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Create and attach ZIP
+        uses: concrete5-community/gh-package-release-attach@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a new [GitHub Release](https://github.com/concrete5-community/gdpr/releases) is published, let's automatically attach to it a ZIP archive with the package.

See for example https://github.com/concrete5-community/easy_image_slider/actions/runs/5807710444/job/15743069506 and https://github.com/concrete5-community/easy_image_slider/releases/tag/1.4.4